### PR TITLE
Add github pages deployment using Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python: 2.7
+cache:
+  directories:
+    - $HOME/.cache/pip
+    - $HOME/.cache/lektor/builds
+install: "pip install Lektor"
+script: "lektor build"
+deploy:
+  provider: script
+  script: "lektor deploy production"

--- a/spyder_website.lektorproject
+++ b/spyder_website.lektorproject
@@ -5,3 +5,6 @@ name = Spider Website
 lektor-webpack-support = 0.1
 lektor-markdown-header-anchors = 0.1
 lektor-disqus-comments = 0.2
+
+[servers.production]
+target = ghpages+https://spyder-ide/spyder.github.io


### PR DESCRIPTION
It will be deployed to [spyder.github.io](http://spyder.github.io)
Now It's using Python2.7 It could be changed to python3 after the next Lektor release
