### PR TITLE
Update to Lektor 3 and build using python3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
     - $HOME/.cache/lektor/builds
 install:
   - "pip install -U pip"
-  - "pip install git+https://github.com/lektor/lektor#egg=Lektor"
+  - "pip install 'Lektor>=3'"
 script: "lektor build"
 deploy:
   provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: 2.7
+python: 3.6
 cache:
   directories:
     - $HOME/.cache/pip


### PR DESCRIPTION
Fixes: #45

Lektor 3 has been realeased and is not longer needed to use git version.