### PR TITLE
PR: Re-add advanced install guide text and link to new docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ The build also requires several [Lektor Plugins](https://www.getlektor.com/docs/
 
 [Download Spyder (with Anaconda)](https://www.anaconda.com/download/)
 
+[Online Documentation](https://docs.spyder-ide.org/)
+
 [Spyder Github](https://github.com/spyder-ide/spyder)
 
 [Troubleshooting Guide and FAQ](

--- a/content/contents.lr
+++ b/content/contents.lr
@@ -241,6 +241,8 @@ content:
 
 The easy way to get up and running with Spyder on any of our supported platforms is to download it as part of the [**Anaconda distribution**](https://www.anaconda.com/download/), and use the `conda` package and environment manager to keep it and your other packages installed and up to date. We recommend the latest 64-bit Python 3 version, unless you have specific requirements that dictate otherwise.
 
+For more advanced users who want a detailed guide to many different methods of obtaining Spyder, please refer to our full [installation instructions](https://docs.spyder-ide.org/installation.html). However, these approaches are generally intended for experienced users only, so we recommend sticking with Anaconda unless you know exactly what you are doing on your own.
+
 
 <a href="https://www.anaconda.com/download/" class="anaconda text-center" target="_blank">
 Download Spyder with Anaconda


### PR DESCRIPTION
Now that our doc site has stabilized at the new URL, we can now add back the relevant link and associated blurb, removed from being originally included in #101 . However, we should probably wait for spyder-ide/spyder-docs#21 to go live first, to ensure a consistent look and feel and the ability to navigate back more easily. (The other pending items shouldn't affect it, since the page has no images and has already been extensively added to, updated and copyedited previously.)