### PR TITLE
PR: Add Spyder FB and Twitter links to website readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,4 +110,8 @@ https://github.com/spyder-ide/spyder/wiki/Troubleshooting-Guide-and-FAQ)
 
 [Google Group](http://groups.google.com/group/spyderlib)
 
+[@Spyder_IDE on Twitter](https://twitter.com/spyder_ide)
+
+[@SpyderIDE on Facebook](https://www.facebook.com/SpyderIDE/)
+
 [Support Spyder on OpenCollective](https://opencollective.com/spyder/)


### PR DESCRIPTION
Essentially, this just adds the links to the readme, ~~Another PR will be needed to actually resolve the issue #113 on the user-facing side.~~

~~Currently, our Facebook and especially Twitter links aren't really linked from anywhere but our OpenCollective to my knowledge~~, and correspondingly have very low SEO rankings and are very hard to find. Therefore, this PR adds them to our readme.