### PR TITLE
PR: Improve header font sizes

### DIFF
--- a/assets/static/css/styles.css
+++ b/assets/static/css/styles.css
@@ -5813,6 +5813,7 @@ screen and (min-width:40em) {
     margin-bottom: 2rem;
     font-family: Raleway;
     color: rgb(78, 78, 78);
+    font-size: 16px;
 }
 
 .blog-post img{
@@ -5851,6 +5852,7 @@ screen and (min-width:40em) {
     color: #000000;
     font-family: Amiri;
     margin-bottom: 25px;
+    font-size: 2.4em;
 }
 
 .blog-post h2{
@@ -5859,7 +5861,7 @@ screen and (min-width:40em) {
     font-family: Amiri;
     margin-top: 40px;
     margin-bottom: 15px;
-    font-size: 2.2em;
+    font-size: 1.8em;
 }
 
 .blog-post h3 {
@@ -5867,6 +5869,7 @@ screen and (min-width:40em) {
     color: #000000;
     font-family: Amiri;
     margin-bottom: 10px;
+    font-size: 1.5em;
 }
 
 .blog-post .blog-index-header .row h1 {

--- a/assets/static/css/styles.css
+++ b/assets/static/css/styles.css
@@ -5813,7 +5813,6 @@ screen and (min-width:40em) {
     margin-bottom: 2rem;
     font-family: Raleway;
     color: rgb(78, 78, 78);
-    font-size: 16px;
 }
 
 .blog-post img{
@@ -5826,7 +5825,7 @@ screen and (min-width:40em) {
 .blog-post p {
     margin-bottom: 1.4rem;
     font-size: inherit;
-    line-height: 1.9;
+    line-height: 1.8;
     text-rendering: optimizeLegibility
 }
 

--- a/models/blog.ini
+++ b/models/blog.ini
@@ -9,4 +9,4 @@ order_by = -pub_date, title
 
 [pagination]
 enabled = yes
-per_page = 5
+per_page = 10


### PR DESCRIPTION
Counterpart to spyder-ide/spyder-docs#48 , which in turn addresses spyder-ide/spyder-docs#26 .

I propose bumping the base blog font size down to 16px, to match the docs (bumped up just slightly) and the general web standard, and bumping the headers down to 2.4em, 1.8em and 1.5em to match the more reasonable 240%/180%/150% of the docs (which are very slightly larger than current docs ones to match the slightly increased normalized base font size). Ideally, it would be nice for this to be done for the release of the first blog post of the new series in #118 . 

Also, due to the modestly decreased size of the titles and (to a lesser extent) bodies on the preview page, as well as to conform to generally accepted practices and show more activity, increases the maximum number of posts shown per page from 5 to 10.