### PR TITLE
PR: Add .gitattributes with linguist overrides for Lektor

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Treat Lektor .lr files as markdown for now, until lektor is added to linguist
+*.lr linguist-language=Markdown
+
+# Treat Lektorproject as .ini for now
+*.lektorproject linguist-language=INI


### PR DESCRIPTION
@goanpeca This should fix the issue of ``.lr`` files in the diffs, etc. not being automatically soft-wrapped by github and treated as prose, and thus make them much easier to read and follow without requiring tedious and problematic hard-wrapping. It will also add proper syntax highlighting for the Markdown portions, as well as make sure the ``lektorproject`` file is handled properly. I've submitted and issue, github/linguist#4151 , and asked them to reopen a PR, github/linguist#2784 , that would fix this more permanently (closed due to popularity at the time) and also properly detect lektor .lr as a language.