### PR TITLE
PR: Rename and update theme submodule to legacy lektor-icon branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
-[submodule "themes/hugo-icon"]
-	path = themes/hugo-icon
-	url = https://github.com/spyder-ide/hugo-icon.git
+[submodule "themes/lektor-icon"]
+	path = themes/lektor-icon
+    branch = legacy
+	url = https://github.com/spyder-ide/lektor-icon.git

--- a/spyder_website.lektorproject
+++ b/spyder_website.lektorproject
@@ -1,6 +1,6 @@
 [project]
 name = Spyder Website
-themes = hugo-icon
+themes = lektor-icon
 url_style = absolute
 url = https://www.spyder-ide.org
 


### PR DESCRIPTION
Renames the ``hugo-icon`` theme and Git submodule to ``lektor-icon``, and pins it to the legacy branch for now.