### PR TITLE
PR: Skip cleanup on Travis to avoid empty deploy to Github Pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,12 @@ script: "ci/build.sh"
 
 deploy:
   - provider: script
+    skip_cleanup: true
     script: "lektor deploy develop --output-path website-spyder-build"
     on:
        branch: develop
   - provider: script
+    skip_cleanup: true
     script: "lektor deploy production --output-path website-spyder-build"
     on:
        branch: production


### PR DESCRIPTION
Previously, we weren't skipping the Travis cleanup step before deploy which reset the repo to the originally checked out state, which since we're now storing our build in the working directory, inside the repo, wipes it out and causes it to not be deployed. This fixes that, as well as adds `.nojekyll` to avoid any Jekyll-related build problems.