### PR TITLE
PR: Fix minor issues with site deploy, unbreak lektor-icon deploy and disable Jekyll properly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,16 @@ script: "ci/build.sh"
 deploy:
   - provider: script
     skip_cleanup: true
-    script: "lektor deploy develop --output-path website-spyder-build"
+    script: "ci/deploy.sh develop"
     on:
        branch: develop
   - provider: script
     skip_cleanup: true
-    script: "lektor deploy production --output-path website-spyder-build"
+    script: "ci/deploy.sh production"
     on:
        branch: production
 
 notifications:
   webhooks:
     urls:
-      - https://webhooks.gitter.im/e/2d23c08216a7b3f1a005
+      - "https://webhooks.gitter.im/e/2d23c08216a7b3f1a005"

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -ex
+
+lektor deploy $1 --output-path website-lektor-icon-build

--- a/spyder_website.lektorproject
+++ b/spyder_website.lektorproject
@@ -3,6 +3,7 @@ name = "Spyder IDE"
 themes = "lektor-icon"
 url_style = "absolute"
 url = "https://www.spyder-ide.org"
+included_assets = ".nojekyll"
 
 [packages]
 lektor-disqus-comments = 0.4.1


### PR DESCRIPTION
This PR:

* Consolidates the deploy commands into a deploy script, to match the fixes in the theme
* Updates the theme with the deploy fixes already applied to the site
* Fixes the .nojekyll file so the 404 page works and Github Pages' Jekyll doesn't interfere with the deploy