### PR TITLE
PR: Fix deploy output path in deploy script

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -ex
 
-lektor deploy $1 --output-path website-lektor-icon-build
+lektor deploy $1 --output-path website-spyder-build


### PR DESCRIPTION
The output path in the deploy script had an issue, leading to an empty deploy on the develop version of the site. This PR fixes it.