### PR TITLE
PR: Add a warning about macOS Big Sur and link to the FAQ question

### DIFF
--- a/content/contents.lr
+++ b/content/contents.lr
@@ -221,6 +221,9 @@ You can also try out Spyder right in your web browser by [launching it on Binder
 For a detailed guide on the many different methods of obtaining Spyder, please refer to our full [installation instructions](https://docs.spyder-ide.org/current/installation.html), and check out our [release page](https://github.com/spyder-ide/spyder/releases/latest) for links to all our installers.
 These approaches are generally intended for experienced users and those with specific needs, so we recommend sticking with the recommended installer unless you have a specific reason to go with another.
 Happy Spydering!
+
+**macOS Big Sur users**: Full support for macOS 11 Big Sur will be included in Spyder 4.2.1, scheduled for release on December 18, 2020.
+However, see [our FAQ question on Big Sur](https://docs.spyder-ide.org/current/faq.html#troubleshooting-macos-bigsur) for how to get it working right now.
 -----
 
 


### PR DESCRIPTION
Adds a warning for macOS Big Sur compatibility and links to the FAQ question added in spyder-ide/spyder-docs#206 with more information and a workaround. Will be reverted after 4.2.1 is released to all channels.