### PR TITLE
Disable no-commit-to-branch pre-commit check to avoid CI lint job failing on merge to master

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -196,12 +196,13 @@ repos:
   - id: check-case-conflict
   - id: check-executables-have-shebangs
     exclude: 'pre\-commit\-config\.yaml'
-  - id: check-merge-conflict
   - id: check-shebang-scripts-are-executable
     exclude: 'pre\-commit\-config\.yaml'
-  - id: no-commit-to-branch
-    name: Prevent commits to wrong branch
-    args: [--branch, master, --branch, main, --pattern, 'v?\d{1,3}\.x']
+  - id: check-merge-conflict
+  # Disable to avoid GitHub CI lint checks failing on merging to production
+  # - id: no-commit-to-branch
+  #   name: Prevent commits to wrong branch
+  #   args: [--branch, master, --branch, main, --pattern, 'v?\d{1,3}\.x']
 
 
 # Commit message hooks #


### PR DESCRIPTION
Disables the `no-commit-to-branch` check to avoid the CI lint job failing on merge to master (we could do some hacky stuff to disable it only on CI, but eh)

Fix #204 