### PR TITLE
Update Binder, standalone installer caveats & Big Sur in Download section

### DIFF
--- a/content/contents.lr
+++ b/content/contents.lr
@@ -215,10 +215,11 @@ content:
 
 Want to join the community of scientists, engineers and analysts all around the world using Spyder?
 Click the button below to download the suggested installer for your platform.
-We offer standalone installers on Windows and macOS, and as our Linux installer is are still experimental, we currently recommend the cross-platform Anaconda distribution for that platform, which includes Spyder and many other useful packages for scientific Python.
+We offer standalone installers on Windows and macOS, and as our Linux installer is are still experimental, we currently recommend the cross-platform Anaconda distribution for that operating system, which includes Spyder and many other useful packages for scientific Python.
 You can also try out Spyder right in your web browser by [launching it on Binder](https://mybinder.org/v2/gh/spyder-ide/binder-environments/spyder-stable?urlpath=git-pull%3Frepo%3Dhttps%253A%252F%252Fgithub.com%252Fspyder-ide%252FSpyder-Workshop%26urlpath%3Ddesktop%252F%26branch%3Dmaster).
 
-Standalone installer support for third-party Spyder plugins and package/environment management is still under development, so we advise installing a Conda-based Python distribution for these use cases.
+The standalone installers don't yet work with third-party plugins, so users needing that should use Spyder through a Conda-based distribution instead.
+Also, they don't currently support installing custom Python packages beyond the basic set pre-installed, so most users will want to have an external Python environment to run their own code, like with any other IDE.
 For a detailed guide to this and the other different ways to obtain Spyder, refer to our full [installation instructions](https://docs.spyder-ide.org/current/installation.html), and check out our [release page](https://github.com/spyder-ide/spyder/releases/latest) for links to all our installers.
 Happy Spydering!
 -----

--- a/content/contents.lr
+++ b/content/contents.lr
@@ -216,7 +216,7 @@ content:
 Want to join the community of scientists, engineers and analysts all around the world using Spyder?
 Click the button below to download the suggested installer for your platform; we offer standalone installers on Windows and macOS.
 For Linux, we recommend the cross-platform Anaconda distribution, which includes Spyder and many other useful packages for scientific Python.
-You can also try out Spyder right in your web browser by [launching it on Binder](https://mybinder.org/v2/gh/spyder-ide/binder-environments/spyder-stable?urlpath=git-pull%3Frepo%3Dhttps%253A%252F%252Fgithub.com%252Fjuanis2112%252FSpyder-Workshop%26urlpath%3Ddesktop%252F%26branch%3DSolutions).
+You can also try out Spyder right in your web browser by [launching it on Binder](https://mybinder.org/v2/gh/spyder-ide/binder-environments/spyder-stable?urlpath=git-pull%3Frepo%3Dhttps%253A%252F%252Fgithub.com%252Fspyder-ide%252FSpyder-Workshop%26urlpath%3Ddesktop%252F%26branch%3Dmaster).
 
 For a detailed guide on the many different methods of obtaining Spyder, please refer to our full [installation instructions](https://docs.spyder-ide.org/current/installation.html), and check out our [release page](https://github.com/spyder-ide/spyder/releases/latest) for links to all our installers.
 These approaches are generally intended for experienced users and those with specific needs, so we recommend sticking with the recommended installer unless you have a specific reason to go with another.

--- a/content/contents.lr
+++ b/content/contents.lr
@@ -214,12 +214,12 @@ full_wdith: false
 content:
 
 Want to join the community of scientists, engineers and analysts all around the world using Spyder?
-Click the button below to download the suggested installer for your platform; we offer standalone installers on Windows and macOS.
-For Linux, we recommend the cross-platform Anaconda distribution, which includes Spyder and many other useful packages for scientific Python.
+Click the button below to download the suggested installer for your platform.
+We offer standalone installers on Windows and macOS, and as our Linux installer is are still experimental, we currently recommend the cross-platform Anaconda distribution for that platform, which includes Spyder and many other useful packages for scientific Python.
 You can also try out Spyder right in your web browser by [launching it on Binder](https://mybinder.org/v2/gh/spyder-ide/binder-environments/spyder-stable?urlpath=git-pull%3Frepo%3Dhttps%253A%252F%252Fgithub.com%252Fspyder-ide%252FSpyder-Workshop%26urlpath%3Ddesktop%252F%26branch%3Dmaster).
 
-For a detailed guide on the many different methods of obtaining Spyder, please refer to our full [installation instructions](https://docs.spyder-ide.org/current/installation.html), and check out our [release page](https://github.com/spyder-ide/spyder/releases/latest) for links to all our installers.
-These approaches are generally intended for experienced users and those with specific needs, so we recommend sticking with the recommended installer unless you have a specific reason to go with another.
+Standalone installer support for third-party Spyder plugins and package/environment management is still under development, so we advise installing a Conda-based Python distribution for these use cases.
+For a detailed guide to this and the other different ways to obtain Spyder, refer to our full [installation instructions](https://docs.spyder-ide.org/current/installation.html), and check out our [release page](https://github.com/spyder-ide/spyder/releases/latest) for links to all our installers.
 Happy Spydering!
 
 **macOS Big Sur users**: Full support for macOS 11 Big Sur will be included in Spyder 4.2.1, scheduled for release on December 18, 2020.

--- a/content/contents.lr
+++ b/content/contents.lr
@@ -218,8 +218,8 @@ Click the button below to download the suggested installer for your platform.
 We offer standalone installers on Windows and macOS, and as our Linux installer is are still experimental, we currently recommend the cross-platform Anaconda distribution for that operating system, which includes Spyder and many other useful packages for scientific Python.
 You can also try out Spyder right in your web browser by [launching it on Binder](https://mybinder.org/v2/gh/spyder-ide/binder-environments/spyder-stable?urlpath=git-pull%3Frepo%3Dhttps%253A%252F%252Fgithub.com%252Fspyder-ide%252FSpyder-Workshop%26urlpath%3Ddesktop%252F%26branch%3Dmaster).
 
-The standalone installers don't yet work with third-party plugins, so users needing that should use Spyder through a Conda-based distribution instead.
-Also, they don't currently support installing custom Python packages beyond the basic set pre-installed, so most users will want to have an external Python environment to run their own code, like with any other IDE.
+The built-in interpreter of the standalone version doesn't currently support installing packages beyond the common scientific libraries bundled with it, so most users will want to have an external Python environment to run their own code, like with any other IDE.
+Also, the standalone installers don't yet work with third-party plugins, so users needing them should use Spyder through a Conda-based distribution instead.
 For a detailed guide to this and the other different ways to obtain Spyder, refer to our full [installation instructions](https://docs.spyder-ide.org/current/installation.html), and check out our [release page](https://github.com/spyder-ide/spyder/releases/latest) for links to all our installers.
 Happy Spydering!
 -----

--- a/content/contents.lr
+++ b/content/contents.lr
@@ -221,9 +221,6 @@ You can also try out Spyder right in your web browser by [launching it on Binder
 Standalone installer support for third-party Spyder plugins and package/environment management is still under development, so we advise installing a Conda-based Python distribution for these use cases.
 For a detailed guide to this and the other different ways to obtain Spyder, refer to our full [installation instructions](https://docs.spyder-ide.org/current/installation.html), and check out our [release page](https://github.com/spyder-ide/spyder/releases/latest) for links to all our installers.
 Happy Spydering!
-
-**macOS Big Sur users**: Full support for macOS 11 Big Sur will be included in Spyder 4.2.1, scheduled for release on December 18, 2020.
-However, see [our FAQ question on Big Sur](https://docs.spyder-ide.org/current/faq.html#troubleshooting-macos-bigsur) for how to get it working right now.
 -----
 
 


### PR DESCRIPTION
Part of spyder-ide/spyder-docs#334

* Update the outdated, broken Binder link
* Revise the download section to reflect the limitations of the standalone installers
* Refine the language in that section and other small related updates
* Elide the mostly out of date (AFAIK) information about macOS Big Sur

Fixes #209 