### PR TITLE
Disable Gitter as script is broken and room is no longer monitored

### DIFF
--- a/spyder_website.lektorproject
+++ b/spyder_website.lektorproject
@@ -56,6 +56,6 @@ footer_license_name = "MIT and others"
 footer_license_link = "https://github.com/spyder-ide/website-spyder/blob/master/NOTICE.txt"
 footer_custom_line = "Feature icons by <a href='https://www.freepik.com/' target='_blank' rel='noopener noreferrer' title='Freepik'>Freepik</a> from <a href='https://www.flaticon.com/' target='_blank' rel='noopener noreferrer' title='Flaticon'>Flaticon.com</a>"
 footer_custom_info_databag =
-gitter_room = "spyder-ide/public"
+gitter_room =
 disqus_name = "spyder-ide"
 atom_enable = true


### PR DESCRIPTION
Currently, the Gitter script snippit that injects the chat window no longer works, and we're also not actively monitoring it. Therefore, simply disable Gitter in the theme for he forseeable future.

Should probably also fix this in the theme, if Gitter still offers something similar, or remove it there too.