### PR TITLE
Fix missing download button due to theme update by un-nesting it

### DIFF
--- a/assets/static/css/custom_styles.css
+++ b/assets/static/css/custom_styles.css
@@ -126,11 +126,7 @@
   min-width: 50%;
 }
 
-/*** Modify download section to allow for multiple buttons ***/
-
-#section-download-buttons {
-  padding-top: 0;
-}
+/*** Download button formatting ***/
 
 #section-download-buttons .content-button {
   margin-bottom: 0;

--- a/assets/static/js/custom_scripts.js
+++ b/assets/static/js/custom_scripts.js
@@ -76,7 +76,7 @@
 
   // On initial DOM ready, set up the tour and the version dropdown
   document.addEventListener("DOMContentLoaded", function () {
-    var downloadButton = document.getElementById("download-button-button");
+    var downloadButton = document.getElementById("download-buttons-button");
     if (downloadButton) {
       setupDownloadButton(downloadButton);
     }

--- a/content/contents.lr
+++ b/content/contents.lr
@@ -225,28 +225,18 @@ Happy Spydering!
 -----
 
 
-##### multisection #####
+##### content #####
 section_id: download-buttons
 -----
-title:
------
-description:
------
-inner_content:
-
-###### content ######
-section_id: download-button
-------
 button_type: text
-------
+-----
 button_content: <span class="download-os-icon"></span><span class="download-text">Download Spyder</span>
-------
+-----
 button_link: https://github.com/spyder-ide/spyder/releases/latest
-------
+-----
 button_position: bottom
-------
+-----
 button_newtab: true
-------
 -----
 ----
 


### PR DESCRIPTION
Due to the minor theme update which was (my mistake) included in #218 , the download button on the main page was silently skipped during rendering. While given nested multisections evidently have some practical use after all (in order to create a containing `div` with a unique ID around multiple elements within a section), it would be ideal to restore this capability, given this is an upstream Lektor limitation and is not needed here, the most practical near-term solution is to simply remove the vestigial nested `multisection`, since it was only there to simplify styling for the multiple download buttons this section previously contained, and no longer does.

Therefore, this PR strips it out, and adjusts the other relevant bits accordingly.

Fixes #219 