### PR TITLE
Fix download button on macOS & add M1 and Intel options

### DIFF
--- a/assets/static/css/custom_styles.css
+++ b/assets/static/css/custom_styles.css
@@ -129,9 +129,9 @@
 /*** Download button formatting ***/
 
 #section-download-buttons .content-button {
-  margin-bottom: 0;
+  margin-bottom: 1em;
   margin-top: 0;
-  min-width: 380px;
+  min-width: 460px;
 }
 
 @media screen and (max-width: 480px) {

--- a/assets/static/js/custom_scripts.js
+++ b/assets/static/js/custom_scripts.js
@@ -4,27 +4,45 @@
   "use strict";
 
   /* Top-level variables */
-  const buttonData = {
-    win: {
-      text: "Download for Windows",
-      icon: ["fab", "fa-windows"],
-      url: "https://github.com/spyder-ide/spyder/releases/latest/download/Spyder_64bit_full.exe",
-    },
-    mac: {
-      text: "Download for macOS",
-      icon: ["fab", "fa-apple"],
-      url: "https://github.com/spyder-ide/spyder/releases/latest/download/Spyder.dmg",
-    },
-    linux: {
-      text: "Download for Linux (Anaconda)",
-      icon: ["fab", "fa-linux"],
-      url: "https://www.anaconda.com/download/",
-    },
-    other: {
-      text: "Download Spyder",
-      icon: ["fas", "fa-download"],
-      url: "https://github.com/spyder-ide/spyder/releases/latest",
-    },
+  const buttonsData = {
+    win: [
+      {
+        id: "download-windows",
+        text: "Download for Windows",
+        icon: ["fab", "fa-windows"],
+        url: "https://github.com/spyder-ide/spyder/releases/latest/download/Spyder_64bit_full.exe",
+      },
+    ],
+    mac: [
+      {
+        id: "download-mac-m1",
+        text: "Download for macOS (M1)",
+        icon: ["fab", "fa-apple"],
+        url: "https://github.com/spyder-ide/spyder/releases/latest/download/Spyder_arm64.dmg",
+      },
+      {
+        id: "download-mac-intel",
+        text: "Download for macOS (Intel)",
+        icon: ["fab", "fa-apple"],
+        url: "https://github.com/spyder-ide/spyder/releases/latest/download/Spyder_x86_64.dmg",
+      },
+    ],
+    linux: [
+      {
+        id: "download-linux",
+        text: "Download for Linux (Anaconda)",
+        icon: ["fab", "fa-linux"],
+        url: "https://www.anaconda.com/download/",
+      },
+    ],
+    other: [
+      {
+        id: "download-other",
+        text: "Download Spyder",
+        icon: ["fas", "fa-download"],
+        url: "https://github.com/spyder-ide/spyder/releases/latest",
+      },
+    ],
   };
 
   /* Helper functions */
@@ -52,24 +70,37 @@
   }
 
   // Get the button data corresponding to the current OS
-  function getButtonData() {
+  function getButtonsData() {
     const osName = getOSName();
-    return buttonData[osName];
+    return buttonsData[osName];
+  }
+
+  // Create the download button nodes from a prototype
+  function createDownloadButton(templateButton, buttonData) {
+    const newButton = templateButton.cloneNode(true);
+    newButton.id = buttonData.id;
+    newButton.href = buttonData.url;
+    newButton.getElementsByClassName("download-text")[0].textContent =
+      buttonData.text;
+    for (const icon of buttonData.icon) {
+      newButton
+        .getElementsByClassName("download-os-icon")[0]
+        .classList.add(icon);
+    }
+    return newButton;
   }
 
   /* Main functions */
 
-  // Setup download button based on current OS
+  // Set up download button based on current OS
   function setupDownloadButton(downloadButton) {
-    const buttonData = getButtonData();
-    downloadButton.href = buttonData.url;
-    downloadButton.getElementsByClassName("download-text")[0].textContent =
-      buttonData.text;
-    for (const icon of buttonData.icon) {
-      downloadButton
-        .getElementsByClassName("download-os-icon")[0]
-        .classList.add(icon);
+    const downloadButtonContainer = document.createElement("div");
+    downloadButtonContainer.id = "download-buttons-container";
+    for (const buttonData of getButtonsData()) {
+      const newButton = createDownloadButton(downloadButton, buttonData);
+      downloadButtonContainer.appendChild(newButton);
     }
+    downloadButton.replaceWith(downloadButtonContainer);
   }
 
   /* Fire events */

--- a/assets/static/js/custom_scripts.js
+++ b/assets/static/js/custom_scripts.js
@@ -4,7 +4,7 @@
   "use strict";
 
   /* Top-level variables */
-  var buttonData = {
+  const buttonData = {
     win: {
       text: "Download for Windows",
       icon: ["fab", "fa-windows"],
@@ -31,7 +31,7 @@
 
   // Get the key corresponding to the current desktop operating system
   function getOSName() {
-    var platform = navigator.platform;
+    const platform = navigator.platform;
     if (!platform) {
       return "other";
     }
@@ -53,7 +53,7 @@
 
   // Get the button data corresponding to the current OS
   function getButtonData() {
-    var osName = getOSName();
+    const osName = getOSName();
     return buttonData[osName];
   }
 
@@ -61,14 +61,14 @@
 
   // Setup download button based on current OS
   function setupDownloadButton(downloadButton) {
-    var buttonData = getButtonData();
+    const buttonData = getButtonData();
     downloadButton.href = buttonData.url;
     downloadButton.getElementsByClassName("download-text")[0].textContent =
       buttonData.text;
-    for (var i = 0; i < buttonData.icon.length; i++) {
+    for (const icon of buttonData.icon) {
       downloadButton
         .getElementsByClassName("download-os-icon")[0]
-        .classList.add(buttonData.icon[i]);
+        .classList.add(icon);
     }
   }
 
@@ -76,7 +76,7 @@
 
   // On initial DOM ready, set up the tour and the version dropdown
   document.addEventListener("DOMContentLoaded", function () {
-    var downloadButton = document.getElementById("download-buttons-button");
+    const downloadButton = document.getElementById("download-buttons-button");
     if (downloadButton) {
       setupDownloadButton(downloadButton);
     }


### PR DESCRIPTION
The website's download button causes a 404 on macOS (Intel and M1) due to the Mac installers being renamed with the 5.5.1 release yesterday and split into x86-64 (Intel) and ARM64 (M1) versions. Unfortunately [it is not reliably possible to detect M1 vs Intel cross-browser and cross-version(https://stackoverflow.com/questions/65146751/detecting-apple-silicon-mac-in-javascript), so the simplest and most reliable solution for now is to just offer two buttons on macOS, one for Intel and one for M1.

For this, I modified the custom function that selects and generates the buttons to handle an arbitrary number of buttons per platform, replacing the existing button element in the HTML with a container containing one or more child buttons, and modifying the CSS accordingly. Additionally, I also took the opportunity to refactor our custom JS to use modern ES6 constructs (`const` and `let` instead of `var`, `for...of` instead of `for`, etc).