### PR TITLE
Update macOS Intel installer link again back to original

### DIFF
--- a/assets/static/js/custom_scripts.js
+++ b/assets/static/js/custom_scripts.js
@@ -24,7 +24,7 @@
         id: "download-mac-intel",
         text: "Download for macOS (Intel)",
         icon: ["fab", "fa-apple"],
-        url: "https://github.com/spyder-ide/spyder/releases/latest/download/Spyder_x86_64.dmg",
+        url: "https://github.com/spyder-ide/spyder/releases/latest/download/Spyder.dmg",
       },
     ],
     linux: [


### PR DESCRIPTION
After discussion, we decided to change the macOS Intel installer filename back to the old undifferentiated version for backward compatibility with the updater on older Spyder versions. Therefore, this PR changes it back. Followup to #223 and counterpart to spyder-ide/spyder-docs#363 .

Fixes spyder-ide/spyder#21924